### PR TITLE
fix(routes/redirect): schema support for duplicate query string params

### DIFF
--- a/src/routes/redirect/schema.js
+++ b/src/routes/redirect/schema.js
@@ -28,10 +28,31 @@ const redirectGetSchema = {
 				S.string()
 					.description("date")
 					.pattern(
-						"^(?:eq|ne|ge|le|gt|lt|sa|eb|ap|)\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}\\:\\d{2}\\:\\d{2}|)$"
+						"^(?:eq|ne|ge|le|gt|lt|sa|eb|ap|)\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}|)$"
 					),
 				S.string().description("string").pattern("^[^<>\"']+$"),
 				S.string().description("uri").format("uri"),
+				S.array()
+					.items(
+						S.anyOf([
+							(S.string()
+								.description("number")
+								.pattern(
+									"^(?:eq|ne|ge|le|gt|lt|sa|eb|ap|)[\\d\\.]+$"
+								),
+							S.string()
+								.description("date")
+								.pattern(
+									"^(?:eq|ne|ge|le|gt|lt|sa|eb|ap|)\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}|)$"
+								)),
+							S.string()
+								.description("string")
+								.pattern("^[^<>\"']+$"),
+						])
+					)
+					.minItems(2)
+					.maxItems(2)
+					.uniqueItems(true),
 			]),
 		})
 		.additionalProperties(false),

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -65,6 +65,34 @@ describe("Server Deployment", () => {
 			expect(response.statusCode).toBe(200);
 		});
 
+		test("Should redirect request to 'redirectUrl' using search route and query string params", async () => {
+			const response = await server.inject({
+				method: "GET",
+				url: "/STU3/Patient",
+				headers: {
+					Authorization: "Bearer testtoken",
+				},
+				query: {
+					identifier: "5484126",
+					birthdate: ["ge2021-01-01", "le2021-05-01"],
+				},
+			});
+
+			expect(response.headers).toEqual(
+				expect.not.objectContaining({
+					"access-control-allow-headers": expect.any(String),
+					"access-control-allow-methods": expect.any(String),
+					"access-control-expose-headers": expect.any(String),
+					etag: expect.any(String),
+					server: expect.any(String),
+					location: expect.any(String),
+					"last-modified": expect.any(String),
+				})
+			);
+
+			expect(response.statusCode).toBe(200);
+		});
+
 		test("Should return HTTP 401 error when invalid bearer token provided in header", async () => {
 			const response = await server.inject({
 				method: "GET",

--- a/test_resources/mocks/mirth-connect-server.mock.js
+++ b/test_resources/mocks/mirth-connect-server.mock.js
@@ -2,6 +2,8 @@ const Fastify = require("fastify");
 
 const mockServer = Fastify();
 
+const redirectGetSchema = require("../../src/routes/redirect/schema");
+
 // Mock FHIR listener channel
 mockServer.route({
 	method: "GET",
@@ -182,6 +184,42 @@ mockServer.route({
 					display: "0 GMP Unknown",
 				},
 			],
+		});
+	},
+});
+
+mockServer.route({
+	method: "GET",
+	schema: redirectGetSchema,
+	url: "/STU3/Patient",
+	handler: (req, res) => {
+		res.headers({
+			"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+			"Access-Control-Allow-Origin": "*",
+			"Access-Control-Expose-Headers": "Content-Location, Location",
+			"Content-Type": "application/fhir+json; charset=UTF-8",
+			ETag: 'W/"1"',
+			Server: "Mirth Connect FHIR Server (3.10.0.b1356)",
+			Location: `http://localhost:444/STU3/Patient/${req.identifier}/_history/1`,
+		});
+
+		// Test patient
+		res.send({
+			resourceType: "Patient",
+			id: req.identifier,
+			meta: {
+				versionId: "1",
+				lastUpdated: "2020-11-16T14:47:07+00:00",
+				profile: [
+					"https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1",
+				],
+			},
+			language: "English (Great Britain)",
+			text: {
+				status: "generated",
+				div:
+					'<div xmlns="http://www.w3.org/1999/xhtml"><div class="hapiHeaderText">Miss Charlotte <b>ZZZTEST </b></div><table class="hapiPropertyTable"><tbody><tr><td>Identifier</td><td>5484126</td></tr><tr><td>Address</td><td><span>The Venue, Unit 3 </span><br/><span>4 Artillery Road &quot; </span><br/><span>Yeovil </span></td></tr><tr><td>Date of birth</td><td><span>29 September 1954</span></td></tr></tbody></table></div>',
+			},
 		});
 	},
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
