### PR TITLE
feat(plugins/jwt-jwks-auth)!: support more than one jwks endpoint

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -167,6 +167,7 @@ AUTH_BEARER_TOKEN_ARRAY=
 # allowedAudiences: String or array of strings containing allowed values for the audience claim - Defaults to allow all audiences if unset or empty
 # allowedAlgorithms: Array of strings of allowed algorithms - Defaults to allow all algorithms if unset or empty
 # allowedIssuers: String or array of strings containing allowed values for the issuer claim - Defaults to allow all issuers if unset or empty
+# allowedSubjects: String or array of strings containing allowed values for the subject claim - Defaults to allow all subjects if unset or empty
 # maxAge: Number specifying the maximum allowed age (in milliseconds) for tokens to still be valid - Defaults to no max age if unset or empty
 #
 # Leaving empty will disable JWT auth

--- a/.env.template
+++ b/.env.template
@@ -160,24 +160,14 @@ AUTH_BEARER_TOKEN_ARRAY=
 
 ### JWKS JWT VALIDATION ###################################
 
-JWKS_ENDPOINT=
-
-# A string or array of strings containing allowed values for the audience claim.
-# Requires JWKS_ENDPOINT to be set.
-# Defaults to allowing all values
-JWT_ALLOWED_AUDIENCE=
-
-# Array of strings of allowed algorithms.
-# Requires JWKS_ENDPOINT to be set.
-# Defaults to allowing all algorithms
-JWT_ALLOWED_ALGO_ARRAY=
-
-# A string or array of strings containing allowed values for the issuer claim.
-# Requires JWKS_ENDPOINT to be set.
-# Defaults to allowing all values
-JWT_ALLOWED_ISSUERS=
-
-# The maximum allowed age (in milliseconds) for tokens to still be valid.
-# Requires JWKS_ENDPOINT to be set.
-# Expects integer or to be unset
-JWT_MAX_AGE=900000
+# Example: [{"jwksEndpoint": "", "allowedAudiences": "ydh", "allowedAlgorithms": ["RS256"], "allowedIssuers": "sider", "maxAge": 90000}]
+#
+# Object values:
+# jwksEndpoint: String - Required
+# allowedAudiences: String or array of strings containing allowed values for the audience claim - Defaults to allow all audiences if unset or empty
+# allowedAlgorithms: Array of strings of allowed algorithms - Defaults to allow all algorithms if unset or empty
+# allowedIssuers: String or array of strings containing allowed values for the issuer claim - Defaults to allow all issuers if unset or empty
+# maxAge: Number specifying the maximum allowed age (in milliseconds) for tokens to still be valid - Defaults to no max age if unset or empty
+#
+# Leaving empty will disable JWT auth
+JWT_JWKS_ARRAY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node: [14, 16]
+                node: [16]
                 os: [macos-latest, ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         steps:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This service was created to provide that functionality, acting as middleware bet
 
 ## Prerequisites
 
--   [Node.js](https://nodejs.org/en/) >=14.0.0 (if running outside of Docker)
+-   [Node.js](https://nodejs.org/en/) >=16.0.0 (if running outside of Docker)
 -   [Mirth Connect](https://github.com/nextgenhealthcare/connect)
 
 ## Setup

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Frazer Smith <frazer.smith@ydh.nhs.uk>",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "benchmark": "autocannon -a 1000 \"http://0.0.0.0:8204/admin/healthcheck\"",

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -47,7 +47,7 @@ describe("Configuration", () => {
 		const RATE_LIMIT_MAX_CONNECTIONS_PER_MIN = "";
 		const RATE_LIMIT_EXCLUDED_ARRAY = '["127.0.0.1"]';
 		const AUTH_BEARER_TOKEN_ARRAY = "";
-		const JWKS_ENDPOINT = "";
+		const JWT_JWKS_ARRAY = "";
 
 		Object.assign(process.env, {
 			NODE_ENV,
@@ -73,7 +73,7 @@ describe("Configuration", () => {
 			RATE_LIMIT_MAX_CONNECTIONS_PER_MIN,
 			RATE_LIMIT_EXCLUDED_ARRAY,
 			AUTH_BEARER_TOKEN_ARRAY,
-			JWKS_ENDPOINT,
+			JWT_JWKS_ARRAY,
 		});
 
 		const config = await getConfig();
@@ -156,13 +156,8 @@ describe("Configuration", () => {
 		const RATE_LIMIT_EXCLUDED_ARRAY = '["127.0.0.1"]';
 		const AUTH_BEARER_TOKEN_ARRAY =
 			'[{"service": "test", "value": "testtoken"}]';
-		const JWKS_ENDPOINT =
-			"https://not-real-issuer.ydh.nhs.uk/auth/realms/SIDER/protocol/openid-connect/certs";
-		const JWT_ALLOWED_AUDIENCE = "who-knows";
-		const JWT_ALLOWED_ALGO_ARRAY = '["RS256"]';
-		const JWT_ALLOWED_ISSUERS =
-			"https://not-real-issuer.ydh.nhs.uk/auth/realms/SIDER";
-		const JWT_MAX_AGE = 900000;
+		const JWT_JWKS_ARRAY =
+			'[{"jwksEndpoint": "https://not-real-issuer.ydh.nhs.uk/auth/realms/SIDER/certs", "allowedAudiences": "ydh", "allowedAlgorithms": ["RS256"], "allowedIssuers": "sider", "maxAge": 90000}]';
 
 		Object.assign(process.env, {
 			NODE_ENV,
@@ -183,11 +178,7 @@ describe("Configuration", () => {
 			RATE_LIMIT_MAX_CONNECTIONS_PER_MIN,
 			RATE_LIMIT_EXCLUDED_ARRAY,
 			AUTH_BEARER_TOKEN_ARRAY,
-			JWKS_ENDPOINT,
-			JWT_ALLOWED_AUDIENCE,
-			JWT_ALLOWED_ALGO_ARRAY,
-			JWT_ALLOWED_ISSUERS,
-			JWT_MAX_AGE,
+			JWT_JWKS_ARRAY,
 		});
 
 		const config = await getConfig();
@@ -241,13 +232,7 @@ describe("Configuration", () => {
 
 		expect(config.bearerTokenAuthKeys).toContain("testtoken");
 
-		expect(config.jwt).toEqual({
-			jwksEndpoint: JWKS_ENDPOINT,
-			allowedAudiences: JWT_ALLOWED_AUDIENCE,
-			allowedAlgorithms: expect.arrayContaining(["RS256"]),
-			allowedIssuers: JWT_ALLOWED_ISSUERS,
-			maxAge: JWT_MAX_AGE,
-		});
+		expect(config.jwt).toEqual(JSON.parse(JWT_JWKS_ARRAY));
 	});
 
 	test("Should return values according to environment variables - HTTPS (PFX cert) enabled and HTTP2 enabled", async () => {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -143,14 +143,7 @@ async function getConfig() {
 			.prop("AUTH_BEARER_TOKEN_ARRAY", S.anyOf([S.string(), S.null()]))
 
 			// JWT Validation
-			.prop(
-				"JWKS_ENDPOINT",
-				S.anyOf([S.string().format("uri"), S.null()])
-			)
-			.prop("JWT_ALLOWED_AUDIENCE", S.anyOf([S.string(), S.null()]))
-			.prop("JWT_ALLOWED_ALGO_ARRAY", S.anyOf([S.string(), S.null()]))
-			.prop("JWT_ALLOWED_ISSUERS", S.anyOf([S.string(), S.null()]))
-			.prop("JWT_MAX_AGE", S.anyOf([S.number(), S.null()]))
+			.prop("JWT_JWKS_ARRAY", S.anyOf([S.string(), S.null()]))
 			.required([
 				"NODE_ENV",
 				"SERVICE_HOST",
@@ -279,16 +272,8 @@ async function getConfig() {
 		redirectUrl: env.SERVICE_REDIRECT_URL,
 	};
 
-	if (env.JWKS_ENDPOINT) {
-		config.jwt = {
-			jwksEndpoint: env.JWKS_ENDPOINT,
-			allowedAudiences: env.JWT_ALLOWED_AUDIENCE,
-			allowedAlgorithms: env.JWT_ALLOWED_ALGO_ARRAY
-				? secJSON.parse(env.JWT_ALLOWED_ALGO_ARRAY)
-				: "",
-			allowedIssuers: env.JWT_ALLOWED_ISSUERS,
-			maxAge: env.JWT_MAX_AGE,
-		};
+	if (env.JWT_JWKS_ARRAY) {
+		config.jwt = secJSON.parse(env.JWT_JWKS_ARRAY);
 	}
 
 	if (env.LOG_ROTATION_FILENAME) {

--- a/src/plugins/jwt-jwks-auth/index.js
+++ b/src/plugins/jwt-jwks-auth/index.js
@@ -41,6 +41,7 @@ async function getSigningKey(token, jwksUri) {
  * @param {string|Array=} options[].allowedAudiences - Accepted recipient(s) that JWT is intended for.
  * @param {Array=} options[].allowedAlgorithms - Accepted signing algorithm(s).
  * @param {string|Array=} options[].allowedIssuers - Accepted principal(s) that issued JWT.
+ * @param {String|Array=} options[].allowedSubjects - Accepted subjects(s).
  * @param {string=} options[].maxAge - The maximum allowed age for tokens to still be valid.
  */
 async function plugin(server, options) {

--- a/src/plugins/jwt-jwks-auth/index.js
+++ b/src/plugins/jwt-jwks-auth/index.js
@@ -65,6 +65,7 @@ async function plugin(server, options) {
 					algorithms: element?.allowedAlgorithms,
 					allowedAud: element?.allowedAudiences,
 					allowedIss: element?.allowedIssuers,
+					allowedSub: element?.allowedSubjects,
 					cache: true,
 					ignoreExpiration: false,
 					key: signingKey,

--- a/src/plugins/jwt-jwks-auth/index.js
+++ b/src/plugins/jwt-jwks-auth/index.js
@@ -54,28 +54,32 @@ async function plugin(server, options) {
 		// Remove 'Bearer' from beginning of token
 		const token = header.replace(/^Bearer/, "").trim();
 
-		// Allow through aslong as the JWT is authenticated by atleast one JWKS endpoint
-		await Promise.any(
-			options.map(async (element) => {
-				const signingKey = await getSigningKey(
-					token,
-					element?.jwksEndpoint
-				);
+		try {
+			// Allow through aslong as the JWT is authenticated by atleast one JWKS endpoint
+			await Promise.any(
+				options.map(async (element) => {
+					const signingKey = await getSigningKey(
+						token,
+						element?.jwksEndpoint
+					);
 
-				const jwtVerifier = createVerifier({
-					algorithms: element?.allowedAlgorithms,
-					allowedAud: element?.allowedAudiences,
-					allowedIss: element?.allowedIssuers,
-					allowedSub: element?.allowedSubjects,
-					cache: true,
-					ignoreExpiration: false,
-					key: signingKey,
-					maxAge: element?.maxAge,
-				});
+					const jwtVerifier = createVerifier({
+						algorithms: element?.allowedAlgorithms,
+						allowedAud: element?.allowedAudiences,
+						allowedIss: element?.allowedIssuers,
+						allowedSub: element?.allowedSubjects,
+						cache: true,
+						ignoreExpiration: false,
+						key: signingKey,
+						maxAge: element?.maxAge,
+					});
 
-				await jwtVerifier(token);
-			})
-		);
+					await jwtVerifier(token);
+				})
+			);
+		} catch (err) {
+			throw new Error("invalid authorization header");
+		}
 	});
 }
 

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -537,7 +537,7 @@ describe("Server Deployment", () => {
 
 							expect(JSON.parse(response.payload)).toEqual({
 								error: "Unauthorized",
-								message: expect.any(String),
+								message: "invalid authorization header",
 								statusCode: 401,
 							});
 							expect(response.headers).toEqual(expResHeadersJson);

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -52,7 +52,8 @@ delete expResHeaders4xxErrors.vary;
 delete expResHeaders4xxErrors["keep-alive"];
 
 describe("Server Deployment", () => {
-	let mockJwksServer;
+	let mockJwksServerOne;
+	let mockJwksServerTwo;
 	let token;
 
 	beforeAll(async () => {
@@ -60,13 +61,19 @@ describe("Server Deployment", () => {
 			SERVICE_REDIRECT_URL: "http://127.0.0.1:3001",
 		});
 
-		mockJwksServer = createJWKSMock(
-			"https://not-real-issuer.ydh.nhs.uk",
-			"/auth/realms/SIDER/protocol/openid-connect/certs"
+		mockJwksServerOne = createJWKSMock(
+			"https://not-real-issuer-valid.ydh.nhs.uk",
+			"/certs"
 		);
-		mockJwksServer.start();
+		mockJwksServerOne.start();
 
-		token = mockJwksServer.token({
+		mockJwksServerTwo = createJWKSMock(
+			"https://not-real-issuer-invalid.ydh.nhs.uk",
+			"/certs"
+		);
+		mockJwksServerTwo.start();
+
+		token = mockJwksServerOne.token({
 			aud: "private",
 			iss: "master",
 		});
@@ -83,7 +90,8 @@ describe("Server Deployment", () => {
 	});
 
 	afterAll(async () => {
-		await mockJwksServer.stop();
+		await mockJwksServerOne.stop();
+		await mockJwksServerTwo.stop();
 		await mockServer.close();
 	});
 
@@ -369,10 +377,7 @@ describe("Server Deployment", () => {
 
 		beforeAll(async () => {
 			Object.assign(process.env, {
-				JWT_ALLOWED_AUDIENCE: "",
-				JWT_ALLOWED_ALGO_ARRAY: "",
-				JWT_ALLOWED_ISSUERS: "",
-				JWT_MAX_AGE: "",
+				JWT_JWKS_ARRAY: "",
 			});
 			currentEnv = { ...process.env };
 		});
@@ -391,8 +396,8 @@ describe("Server Deployment", () => {
 				envVariables: {
 					AUTH_BEARER_TOKEN_ARRAY:
 						'[{"service": "test", "value": "testtoken"}]',
-					JWKS_ENDPOINT:
-						"https://not-real-issuer.ydh.nhs.uk/auth/realms/SIDER/protocol/openid-connect/certs",
+					JWT_JWKS_ARRAY:
+						'[{"jwksEndpoint": "https://not-real-issuer-valid.ydh.nhs.uk/certs"}]',
 				},
 			},
 			{
@@ -401,16 +406,35 @@ describe("Server Deployment", () => {
 				envVariables: {
 					AUTH_BEARER_TOKEN_ARRAY:
 						'[{"service": "test", "value": "testtoken"}]',
-					JWKS_ENDPOINT: "",
+					JWT_JWKS_ARRAY: "",
 				},
 			},
 			{
 				testName:
-					"Bearer Token Auth Disabled and JWKS JWT Auth Enabled",
+					"Bearer Token Auth Disabled and JWKS JWT Auth Enabled With One JWKS Endpoint",
 				envVariables: {
 					AUTH_BEARER_TOKEN_ARRAY: "",
-					JWKS_ENDPOINT:
-						"https://not-real-issuer.ydh.nhs.uk/auth/realms/SIDER/protocol/openid-connect/certs",
+					JWT_JWKS_ARRAY:
+						'[{"jwksEndpoint": "https://not-real-issuer-valid.ydh.nhs.uk/certs"}]',
+				},
+			},
+			{
+				testName:
+					"Bearer Token Auth Disabled and Jwks Jwt Auth Enabled With Two Jwks Endpoints (With Valid Key for One)",
+				envVariables: {
+					AUTH_BEARER_TOKEN_ARRAY: "",
+					JWT_JWKS_ARRAY:
+						'[{"jwksEndpoint": "https://not-real-issuer-valid.ydh.nhs.uk/certs"},{"jwksEndpoint": "https://not-real-issuer-invalid.ydh.nhs.uk/certs"}]',
+				},
+			},
+
+			{
+				testName:
+					"Bearer Token Auth Disabled and Jwks Jwt Auth Enabled With One Jwks Endpoint (With an Invalid Key)",
+				envVariables: {
+					AUTH_BEARER_TOKEN_ARRAY: "",
+					JWT_JWKS_ARRAY:
+						'[{"jwksEndpoint": "https://not-real-issuer-invalid.ydh.nhs.uk/certs"}]',
 				},
 			},
 		];
@@ -472,7 +496,11 @@ describe("Server Deployment", () => {
 						});
 					}
 
-					if (testObject?.envVariables?.JWKS_ENDPOINT !== "") {
+					if (
+						testObject?.envVariables?.JWT_JWKS_ARRAY !== "" &&
+						testObject?.envVariables?.JWT_JWKS_ARRAY !==
+							'[{"jwksEndpoint": "https://not-real-issuer-invalid.ydh.nhs.uk/certs"}]'
+					) {
 						test("Should redirect request to 'redirectUrl' using JWKS JWT auth", async () => {
 							const response = await server.inject({
 								method: "GET",
@@ -492,7 +520,11 @@ describe("Server Deployment", () => {
 						});
 					}
 
-					if (testObject?.envVariables?.JWKS_ENDPOINT === "") {
+					if (
+						testObject?.envVariables?.JWT_JWKS_ARRAY === "" ||
+						testObject?.envVariables?.JWT_JWKS_ARRAY ===
+							'[{"jwksEndpoint": "https://not-real-issuer-invalid.ydh.nhs.uk/certs"}]'
+					) {
 						test("Should fail to redirect request to 'redirectUrl' using JWKS JWT auth", async () => {
 							const response = await server.inject({
 								method: "GET",


### PR DESCRIPTION
BREAKING CHANGE: `JWKS_ENDPOINT`, `JWT_ALLOWED_AUDIENCE`, `JWT_ALLOWED_ISSUERS`, `JWT_ALLOWED_ALGO_ARRAY`, and `JWT_MAX_AGE` env variables removed. Use new `JWT_JWKS_ARRAY` env variable.

closes https://github.com/Fdawgs/ydh-fhir-authentication-service/issues/499